### PR TITLE
Use "pull_request_target" event instead of pull_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 A GitHub action to automatically close a pull request.
 
-Note that only pull requests being opened from the same repository can be closed. This action will not currently work for pull requests from forks -- like is common in open source projects -- because the token for forked pull request workflows does not have write permissions.
-
 ## Usage
 
-This Action subscribes to `pull_request` events. When receiving a `pull_request` event, this action closes the pull request triggered by the event immediately.
+This Action subscribes to `pull_request_target` events. When receiving a `pull_request_target` event, this action closes the pull request triggered by the event immediately.
+
+See [Events that trigger workflows](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target) for more details about the `pull_request_target` event.
 
 ```yaml
 name: Close Pull Request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -3973,7 +3973,7 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 const run = async () => {
   const context = github.context;
 
-  if (context.eventName !== "pull_request") {
+  if (context.eventName !== "pull_request_target") {
     throw errors.ignoreEvent;
   }
 
@@ -8982,7 +8982,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.noToken = exports.ignoreEvent = void 0;
-const ignoreEvent = new Error("Ignoring this event (only listens for 'pull_request')");
+const ignoreEvent = new Error("Ignoring this event (only listens for 'pull_request_target')");
 exports.ignoreEvent = ignoreEvent;
 const noToken = new Error("You have to provide the GITHUB_TOKEN inside your secrets configuration and provide it as an env variable");
 exports.noToken = noToken;

--- a/src/close-pull-request.js
+++ b/src/close-pull-request.js
@@ -4,7 +4,7 @@ import * as errors from "./errors";
 
 export const run = async () => {
   const context = github.context;
-  if (context.eventName !== "pull_request") {
+  if (context.eventName !== "pull_request_target") {
     throw errors.ignoreEvent;
   }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,5 +1,5 @@
 export const ignoreEvent = new Error(
-  "Ignoring this event (only listens for 'pull_request')"
+  "Ignoring this event (only listens for 'pull_request_target')"
 );
 export const noToken = new Error(
   "You have to provide the GITHUB_TOKEN inside your secrets configuration and provide it as an env variable"

--- a/tests/close-pull-request.test.js
+++ b/tests/close-pull-request.test.js
@@ -15,7 +15,7 @@ describe("Close Pull Request", () => {
     update = jest.fn().mockResolvedValue();
     createComment = jest.fn().mockResolvedValue();
 
-    context.eventName = "pull_request";
+    context.eventName = "pull_request_target";
 
     context.repo = {
       owner: "owner",
@@ -49,7 +49,7 @@ describe("Close Pull Request", () => {
     });
   });
 
-  describe("when event type is not pull_request", () => {
+  describe("when event type is not pull_request_target", () => {
     beforeEach(() => {
       context.eventName = "push";
     });


### PR DESCRIPTION
This action accepts the `pull_request` event, so it is not possible to
close PRs from forked repositories. With this change, the problem is
resolved by accepting the new `pull_request_target` event instead.

Fixes #9 