### PR TITLE
Add github_token input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ jobs:
       with:
         # Optional. Post a issue comment just before closing a pull request.
         comment: "We do not accept PRs. If you have any questions, please feel free to contact us."
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   comment:
     description: "Post a issue comment just before closing a pull request."
     required: false
+  github_token:
+    description: "Token used to close a pull request and create an issue comment"
+    required: false
+    default: ${{ github.token }}
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -4039,15 +4039,18 @@ const run = async () => {
     throw errors.ignoreEvent;
   }
 
-  const token = process.env["GITHUB_TOKEN"] || "";
+  let token = process.env["GITHUB_TOKEN"] || "";
 
   if (token === "") {
-    throw errors.noToken;
+    token = core.getInput("github_token");
+  } else {
+    core.warning("GITHUB_TOKEN environment variable is deprecated.");
+    core.warning("GitHub Token is passed automatically, so no longer needs to be set.");
   }
 
   const client = new github.GitHub(token); // *Optional*. Post an issue comment just before closing a pull request.
 
-  const body = core.getInput("comment");
+  const body = core.getInput("comment") || "";
 
   if (body.length > 0) {
     core.info("Creating a comment");

--- a/src/close-pull-request.js
+++ b/src/close-pull-request.js
@@ -8,15 +8,20 @@ export const run = async () => {
     throw errors.ignoreEvent;
   }
 
-  const token = process.env["GITHUB_TOKEN"] || "";
+  let token = process.env["GITHUB_TOKEN"] || "";
   if (token === "") {
-    throw errors.noToken;
+    token = core.getInput("github_token");
+  } else {
+    core.warning("GITHUB_TOKEN environment variable is deprecated.");
+    core.warning(
+      "GitHub Token is passed automatically, so no longer needs to be set."
+    );
   }
 
   const client = new github.GitHub(token);
 
   // *Optional*. Post an issue comment just before closing a pull request.
-  const body = core.getInput("comment");
+  const body = core.getInput("comment") || "";
   if (body.length > 0) {
     core.info("Creating a comment");
     await client.issues.createComment({


### PR DESCRIPTION
`GITHUB_TOKEN` environment variable is deprecated and github_token input
automatically pass GitHub Token instead. Users no longer need to
manually set GitHub Token.